### PR TITLE
Fixes #2 sync drift and size animations in NumberBricks for consistent animated scaling

### DIFF
--- a/numberbricks/src/main/kotlin/io/github/beankitk/numberbricks/NumberBricks.kt
+++ b/numberbricks/src/main/kotlin/io/github/beankitk/numberbricks/NumberBricks.kt
@@ -189,7 +189,6 @@ private fun NumberBricksImpl(
     
     val baseBrickSize = 1.dp
     val brickSizeDp = baseBrickSize * brickSizeMultiplier
-    
     val width = brickSizeDp * 3f
     val height = brickSizeDp * 5f
     
@@ -201,7 +200,7 @@ private fun NumberBricksImpl(
         if (!wasFirstVisible) {
             Array(13) { Offset(1f, 2f) }
         } else {
-            Array(13) { Offset.Unspecified }.also { it.getOffsetsFor(digit) }
+            Array(13) { Offset.Unspecified }.also { it.fillOffsetsFor(digit) }
         }
     }
     
@@ -210,27 +209,31 @@ private fun NumberBricksImpl(
     val targetOffsets = remember { Array(13) { Offset.Unspecified } }
     
     LaunchedEffect(digit, animateDigits) {
-        val isDigitChange = previousDigit != digit
-        if (wasFirstVisible && !isDigitChange && progress.value == 1f) return@LaunchedEffect
-    
-        targetOffsets.getOffsetsFor(digit)
-        endOffsets.copyInto(startOffsets)
-        targetOffsets.copyInto(endOffsets)
+        if (wasFirstVisible && previousDigit == digit && progress.value == 1f) 
+            return@LaunchedEffect
+            
+        if (previousDigit != digit) {
+            targetOffsets.fillOffsetsFor(digit)
+            endOffsets.copyInto(startOffsets)
+            targetOffsets.copyInto(endOffsets)
+            previousDigit = digit
+        }
+        
+        val shouldAnimate = when {
+            !animateDigits -> false
+            !wasFirstVisible -> {
+                wasFirstVisible = true
+                animateOnFirstVisible
+            }
+            else -> true
+        }
         
         progress.snapTo(0f)
-        if (!animateDigits) {
-            progress.snapTo(1f)
-        } else if (!wasFirstVisible) {
-            if (animateOnFirstVisible) {
-                progress.animateTo(1f, animationSpec)
-            } else {
-                progress.snapTo(1f)
-            }    
-            wasFirstVisible = true
+        if (shouldAnimate) {
+            progress.animateTo(1f, animationSpec)
         } else {
-            progress.animateTo(1f,animationSpec)
+            progress.snapTo(1f)
         }
-        previousDigit = digit
     }
     
     Spacer(

--- a/numberbricks/src/main/kotlin/io/github/beankitk/numberbricks/Utilities.kt
+++ b/numberbricks/src/main/kotlin/io/github/beankitk/numberbricks/Utilities.kt
@@ -29,120 +29,120 @@ internal val animatableSaver: Saver<Animatable<Float, AnimationVector1D>, Float>
         restore = { value -> Animatable(value) }
     )
 
-internal fun Array<Offset>.getOffsetsFor(digit: Int) {
+internal fun Array<Offset>.fillOffsetsFor(digit: Int) {
     val layout = DIGIT_LAYOUTS.getOrElse(digit) { DIGIT_LAYOUTS[10] }
     for (i in indices) {
-        val xIndex = layout[i * 2].toFloat()
-        val yIndex = layout[i * 2 + 1].toFloat()
+        val xIndex = layout[i * 2]
+        val yIndex = layout[i * 2 + 1]
         this[i] = Offset(xIndex, yIndex)
     }
 }
 
-private val DIGIT_LAYOUTS: Array<ByteArray> = arrayOf(
+private val DIGIT_LAYOUTS: Array<FloatArray> = arrayOf(
     // digit 0
-    byteArrayOf(
-        0,0, 1,0, 2,0,
-        0,1, 2,1,
-        0,2, 0,2, 2,2,
-        0,3, 2,3,
-        0,4, 1,4, 2,4
+    floatArrayOf(
+        0f,0f, 1f,0f, 2f,0f,
+        0f,1f, 2f,1f,
+        0f,2f, 0f,2f, 2f,2f,
+        0f,3f, 2f,3f,
+        0f,4f, 1f,4f, 2f,4f
     ),
     // digit 1
-    byteArrayOf(
-        0,0, 1,0, 1,0,
-        1,1, 1,1,
-        1,2, 1,2, 1,2,
-        1,3, 1,3,
-        0,4, 1,4, 2,4
+    floatArrayOf(
+        0f,0f, 1f,0f, 1f,0f,
+        1f,1f, 1f,1f,
+        1f,2f, 1f,2f, 1f,2f,
+        1f,3f, 1f,3f,
+        0f,4f, 1f,4f, 2f,4f
     ),
     // digit 2
-    byteArrayOf(
-        0,0, 1,0, 2,0,
-        2,1, 2,1,
-        0,2, 1,2, 2,2,
-        0,3, 0,3,
-        0,4, 1,4, 2,4
+    floatArrayOf(
+        0f,0f, 1f,0f, 2f,0f,
+        2f,1f, 2f,1f,
+        0f,2f, 1f,2f, 2f,2f,
+        0f,3f, 0f,3f,
+        0f,4f, 1f,4f, 2f,4f
     ),
     // digit 3
-    byteArrayOf(
-        0,0, 1,0, 2,0,
-        2,1, 2,1,
-        0,2, 1,2, 2,2,
-        2,3, 2,3,
-        0,4, 1,4, 2,4
+    floatArrayOf(
+        0f,0f, 1f,0f, 2f,0f,
+        2f,1f, 2f,1f,
+        0f,2f, 1f,2f, 2f,2f,
+        2f,3f, 2f,3f,
+        0f,4f, 1f,4f, 2f,4f
     ),
     // digit 4
-    byteArrayOf(
-        0,0, 2,0, 2,0,
-        0,1, 2,1,
-        0,2, 1,2, 2,2,
-        2,3, 2,3,
-        2,4, 2,4, 2,4
+    floatArrayOf(
+        0f,0f, 2f,0f, 2f,0f,
+        0f,1f, 2f,1f,
+        0f,2f, 1f,2f, 2f,2f,
+        2f,3f, 2f,3f,
+        2f,4f, 2f,4f, 2f,4f
     ),
     // digit 5
-    byteArrayOf(
-        0,0, 1,0, 2,0,
-        0,1, 2,0,
-        0,2, 1,2, 2,2,
-        2,3, 2,3,
-        0,4, 1,4, 2,4
+    floatArrayOf(
+        0f,0f, 1f,0f, 2f,0f,
+        0f,1f, 2f,0f,
+        0f,2f, 1f,2f, 2f,2f,
+        2f,3f, 2f,3f,
+        0f,4f, 1f,4f, 2f,4f
     ),
     // digit 6
-    byteArrayOf(
-        0,0, 1,0, 2,0,
-        0,1, 2,0,
-        0,2, 1,2, 2,2,
-        0,3, 2,3,
-        0,4, 1,4, 2,4
+    floatArrayOf(
+        0f,0f, 1f,0f, 2f,0f,
+        0f,1f, 2f,0f,
+        0f,2f, 1f,2f, 2f,2f,
+        0f,3f, 2f,3f,
+        0f,4f, 1f,4f, 2f,4f
     ),
     // digit 7
-    byteArrayOf(
-        0,0, 1,0, 2,0,
-        2,1, 2,1,
-        1,2, 1,2, 2,2,
-        2,3, 2,3,
-        2,4, 2,4, 2,4
+    floatArrayOf(
+        0f,0f, 1f,0f, 2f,0f,
+        2f,1f, 2f,1f,
+        1f,2f, 1f,2f, 2f,2f,
+        2f,3f, 2f,3f,
+        2f,4f, 2f,4f, 2f,4f
     ),
     // digit 8
-    byteArrayOf(
-        0,0, 1,0, 2,0,
-        0,1, 2,1,
-        0,2, 1,2, 2,2,
-        0,3, 2,3,
-        0,4, 1,4, 2,4
+    floatArrayOf(
+        0f,0f, 1f,0f, 2f,0f,
+        0f,1f, 2f,1f,
+        0f,2f, 1f,2f, 2f,2f,
+        0f,3f, 2f,3f,
+        0f,4f, 1f,4f, 2f,4f
     ),
     // digit 9
-    byteArrayOf(
-        0,0, 1,0, 2,0,
-        0,1, 2,1,
-        0,2, 1,2, 2,2,
-        0,4, 2,3,
-        0,4, 1,4, 2,4
+    floatArrayOf(
+        0f,0f, 1f,0f, 2f,0f,
+        0f,1f, 2f,1f,
+        0f,2f, 1f,2f, 2f,2f,
+        0f,4f, 2f,3f,
+        0f,4f, 1f,4f, 2f,4f
     ),
-    //default at center 1,2 
-    byteArrayOf(
-        1,2, 1,2, 1,2,
-        1,2, 1,2, 
-        1,2, 1,2, 1,2,
-        1,2, 1,2,
-        1,2, 1,2, 1,2,
+    // default at center 1,2 
+    floatArrayOf(
+        1f,2f, 1f,2f, 1f,2f,
+        1f,2f, 1f,2f, 
+        1f,2f, 1f,2f, 1f,2f,
+        1f,2f, 1f,2f,
+        1f,2f, 1f,2f, 1f,2f
     )
     /**
     old 1
-    byteArrayOf(
-        2,0, 2,0, 2,0,
-        2,1, 2,1,
-        2,2, 2,2, 2,2,
-        2,3, 2,3,
-        2,4, 2,4, 2,4
+    floatArrayOf(
+        2f,0f, 2f,0f, 2f,0f,
+        2f,1f, 2f,1f,
+        2f,2f, 2f,2f, 2f,2f,
+        2f,3f, 2f,3f,
+        2f,4f, 2f,4f, 2f,4f
     ),
     old 7
-    byteArrayOf(
-        0,0, 1,0, 2,0,
-        2,1, 2,1,
-        2,2, 2,2, 2,2,
-        2,3, 2,3,
-        2,4, 2,4, 2,4
+    floatArrayOf(
+        0f,0f, 1f,0f, 2f,0f,
+        2f,1f, 2f,1f,
+        2f,2f, 2f,2f, 2f,2f,
+        2f,3f, 2f,3f,
+        2f,4f, 2f,4f, 2f,4f
     ),
     */
 )


### PR DESCRIPTION
1. Synced drift and size animations in `NumberBricks` for smooth scaling during size changes.
2. Offsets now stored in unit space and update only on digit change, reducing per-frame call when animating.
3. Cached brick size inside `drawWithCache` to automatically reflect size animation changes.
4. Fixed inconsistent brick size issue when shrinking (#1).
5. Simplified animation logic with `shouldAnimate` flag and single `snapTo`/`animateTo` path.
6. `computeOffsetsFor` has been renamed to `getOffsetsFor`.
7. Digit position are stored in `FloatArray` instead of `ByteArray` to reduce `toFloat` calls.

See #2 for more details.